### PR TITLE
Fixed memory leak

### DIFF
--- a/src/PowerPipe.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtension.cs
+++ b/src/PowerPipe.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtension.cs
@@ -7,8 +7,17 @@ namespace PowerPipe.Extensions.MicrosoftDependencyInjection;
 
 public static class ServiceCollectionExtension
 {
-    public static IServiceCollection AddPowerPipe(this IServiceCollection serviceCollection) =>
-        serviceCollection.AddSingleton<IPipelineStepFactory, PipelineStepFactory>();
+    public static IServiceCollection AddPowerPipe(
+        this IServiceCollection serviceCollection, ServiceLifetime lifetime = ServiceLifetime.Transient)
+    {
+        return lifetime switch
+        {
+            ServiceLifetime.Transient => serviceCollection.AddTransient<IPipelineStepFactory, PipelineStepFactory>(),
+            ServiceLifetime.Scoped => serviceCollection.AddScoped<IPipelineStepFactory, PipelineStepFactory>(),
+            ServiceLifetime.Singleton => serviceCollection.AddSingleton<IPipelineStepFactory, PipelineStepFactory>(),
+            _ => throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null)
+        };
+    }
 
     public static IServiceCollection AddPowerPipeStep<TStep, TContext>(
         this IServiceCollection serviceCollection, ServiceLifetime lifetime = ServiceLifetime.Transient)


### PR DESCRIPTION
Due to the factory being registered as a singleton, it was holding references to objects that were never disposed of.

Added switch with ServiceLifetime to choose a lifetime on demand. By default, lifetime is set as Transient.

Consider register factory with the same lifetime as your steps.