### PR TITLE
Fixed false OnError call when exception raised from different step

### DIFF
--- a/src/PowerPipe/AssemblyInfo.cs
+++ b/src/PowerPipe/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PowerPipe.UnitTests")]

--- a/src/PowerPipe/Builder/Steps/InternalStep.cs
+++ b/src/PowerPipe/Builder/Steps/InternalStep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using PowerPipe.Exceptions;
 using PowerPipe.Interfaces;
 
 namespace PowerPipe.Builder.Steps;
@@ -33,12 +34,12 @@ internal abstract class InternalStep<TContext> : IPipelineStep<TContext>
         {
             await ExecuteInternalAsync(context, cancellationToken);
         }
-        catch (Exception)
+        catch (Exception e) when (e is not PipelineExecutionException)
         {
             var errorHandleSucceed = await HandleExceptionAsync(context, cancellationToken);
 
             if(!errorHandleSucceed)
-                throw;
+                throw new PipelineExecutionException(e);
         }
     }
 

--- a/src/PowerPipe/Exceptions/PipelineExecutionException.cs
+++ b/src/PowerPipe/Exceptions/PipelineExecutionException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PowerPipe.Exceptions;
+
+internal class PipelineExecutionException : Exception
+{
+    public PipelineExecutionException(Exception exception)
+        : base("Pipeline execution failed", exception)
+    {
+    }
+}

--- a/tests/PowerPipe.UnitTests/PipelineTests.cs
+++ b/tests/PowerPipe.UnitTests/PipelineTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using PowerPipe.Builder;
 using PowerPipe.Builder.Steps;
+using PowerPipe.Exceptions;
 using PowerPipe.Factories;
 using PowerPipe.UnitTests.Steps;
 
@@ -133,10 +134,8 @@ public class PipelineTests
     {
         var step = Substitute.For<TestStep1>();
 
-        var exceptionMessage = "Test message";
-
         step.ExecuteAsync(Arg.Any<TestPipelineContext>(), Arg.Any<CancellationToken>())
-            .Returns(_ => throw new InvalidOperationException(exceptionMessage));
+            .Returns(_ => throw new InvalidOperationException("Test message"));
 
         var context = new TestPipelineContext();
         var cts = new CancellationTokenSource();
@@ -162,20 +161,20 @@ public class PipelineTests
         {
             if (isRetryBehaviour)
             {
-                await action.Should().ThrowAsync<InvalidOperationException>().WithMessage(exceptionMessage);
+                await action.Should().ThrowAsync<PipelineExecutionException>();
 
                 await step.Received(1 + retryCount).ExecuteAsync(Arg.Is(context), Arg.Is(cts.Token));
             }
             else
             {
-                await action.Should().NotThrowAsync<InvalidOperationException>();
+                await action.Should().NotThrowAsync<PipelineExecutionException>();
 
                 await step.Received(1).ExecuteAsync(Arg.Is(context), Arg.Is(cts.Token));
             }
         }
         else
         {
-            await action.Should().ThrowAsync<InvalidOperationException>().WithMessage(exceptionMessage);
+            await action.Should().ThrowAsync<PipelineExecutionException>();
         }
     }
 }


### PR DESCRIPTION
If the pipeline has two steps A and B with ErrorHandling added by OnError method and an exception is raised by step B error handling will be executed on both steps.

To prevent this error handling will be executed on all errors except internal PipelineExecutionException.