### PR TITLE
Refactoring fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,23 +3,50 @@ name: Build & Test
 on:
   push:
     branches: [ "master" ]
-  pull_request: 
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [net8.0, net9.0, net10.0]
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           8.0.x
           9.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore
-    - name: Build&Test
+    - name: Build
+      run: dotnet build --no-restore --verbosity normal
+    - name: Test
+      run: dotnet test -f ${{ matrix.framework }} -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover --no-build --verbosity normal
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Test with coverage
       run: dotnet test -f net8.0 -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover --no-restore --verbosity normal
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,63 +6,44 @@ on:
       - 'v*'
 
 env:
-  PROJECT_NAME: 'PowerPipe'
-  PROJECT_PATH: 'src/PowerPipe/PowerPipe.csproj'
-
-  PROJECT_EXTENSIONS_NAME: 'PowerPipe.Extensions.MicrosoftDependencyInjection'
-  PROJECT_EXTENSIONS_PATH: 'src/PowerPipe.Extensions.MicrosoftDependencyInjection/PowerPipe.Extensions.MicrosoftDependencyInjection.csproj'
-
-  PROJECT_VISUALIZATION_NAME: 'PowerPipe.Visualization'
-  PROJECT_VISUALIZATION_PATH: 'src/PowerPipe.Visualization/PowerPipe.Visualization.csproj'
-
-  PROJECT_VISUALIZATION_EXTENSIONS_NAME: 'PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection'
-  PROJECT_VISUALIZATION_EXTENSIONS_PATH: 'src/PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection/PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection.csproj'
-
-  PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}\output
+  PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/output
   NUGET_SOURCE_URL: 'https://api.nuget.org/v3/index.json'
 
 jobs:
   publish:
-    name: Build&Publish packages
-    runs-on: 'windows-latest'
+    name: Build & Publish packages
+    runs-on: ubuntu-latest
+
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Get Version
         id: version
-        uses: nowsprinting/check-version-format-action@v3
+        uses: nowsprinting/check-version-format-action@v4
         with:
           prefix: 'v'
 
-      - name: Build&Publish PowerPipe
-        run: |
-          dotnet build ${{ env.PROJECT_PATH }} --no-restore --configuration Release
-          dotnet pack ${{ env.PROJECT_PATH }} --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
-          dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}\${{ env.PROJECT_NAME }}.${{ steps.version.outputs.full_without_prefix }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }}
+      - name: Build Release
+        run: dotnet build --no-restore --configuration Release
 
-      - name: Build&Publish PowerPipe.Extensions.MicrosoftDependencyInjection
+      - name: Pack all projects
         run: |
-          dotnet build ${{ env.PROJECT_EXTENSIONS_PATH }} --no-restore --configuration Release
-          dotnet pack ${{ env.PROJECT_EXTENSIONS_PATH }} --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
-          dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}\${{ env.PROJECT_EXTENSIONS_NAME }}.${{ steps.version.outputs.full_without_prefix }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }}
+          dotnet pack src/PowerPipe/PowerPipe.csproj --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
+          dotnet pack src/PowerPipe.Extensions.MicrosoftDependencyInjection/PowerPipe.Extensions.MicrosoftDependencyInjection.csproj --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
+          dotnet pack src/PowerPipe.Visualization/PowerPipe.Visualization.csproj --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
+          dotnet pack src/PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection/PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection.csproj --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
 
-      - name: Build&Publish PowerPipe.Visualization
-        run: |
-          dotnet build ${{ env.PROJECT_VISUALIZATION_PATH }} --no-restore --configuration Release
-          dotnet pack ${{ env.PROJECT_VISUALIZATION_PATH }} --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
-          dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}\${{ env.PROJECT_VISUALIZATION_NAME }}.${{ steps.version.outputs.full_without_prefix }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }}
-
-      - name: Build&Publish PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection
-        run: |
-          dotnet build ${{ env.PROJECT_VISUALIZATION_EXTENSIONS_PATH }} --no-restore --configuration Release
-          dotnet pack ${{ env.PROJECT_VISUALIZATION_EXTENSIONS_PATH }} --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.full_without_prefix }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
-          dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}\${{ env.PROJECT_VISUALIZATION_EXTENSIONS_NAME }}.${{ steps.version.outputs.full_without_prefix }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }}
+      - name: Push to NuGet
+        run: dotnet nuget push "${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }} --skip-duplicate

--- a/samples/PowerPipe.Sample/Steps/SampleGenericStep.cs
+++ b/samples/PowerPipe.Sample/Steps/SampleGenericStep.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using PowerPipe.Interfaces;

--- a/src/PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtension.cs
+++ b/src/PowerPipe.Visualization.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtension.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Extensions.Options;
 using PowerPipe.Visualization;
 using PowerPipe.Visualization.Configurations;
 

--- a/src/PowerPipe.Visualization/PipelineDiagramsService.cs
+++ b/src/PowerPipe.Visualization/PipelineDiagramsService.cs
@@ -30,8 +30,8 @@ public class PipelineDiagramsService : IPipelineDiagramService
     /// <param name="loggerFactory">Logger factory</param>
     public PipelineDiagramsService(IOptions<PowerPipeVisualizationConfiguration> configuration, ILoggerFactory loggerFactory)
     {
-        ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
-        ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
         
         _configuration = configuration.Value;
 
@@ -41,6 +41,11 @@ public class PipelineDiagramsService : IPipelineDiagramService
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Diagrams are cached after the first call. Subsequent calls return the cached result
+    /// without re-scanning assemblies or re-decompiling types. There is no cache invalidation;
+    /// if pipeline definitions change at runtime, restart the application to refresh diagrams.
+    /// </remarks>
     public IDictionary<string, string> GetDiagrams()
     {
         if (_diagrams.Count > 0)
@@ -74,7 +79,7 @@ public class PipelineDiagramsService : IPipelineDiagramService
         }
         catch (Exception e)
         {
-            _logger.LogDebug("Exception occured during retrieving of diagrams. {Exception}", e);
+            _logger.LogError(e, "Exception occured during retrieving of diagrams.");
         }
 
         return _diagrams;

--- a/src/PowerPipe/Builder/PipelineBuilder.cs
+++ b/src/PowerPipe/Builder/PipelineBuilder.cs
@@ -13,11 +13,10 @@ namespace PowerPipe.Builder;
 /// <typeparam name="TResult">The type of result returned by the pipeline.</typeparam>
 public sealed class PipelineBuilder<TContext, TResult>
     where TContext : PipelineContext<TResult>
-    where TResult : class
 {
     private readonly IPipelineStepFactory _pipelineStepFactory;
     private readonly ILoggerFactory _loggerFactory;
-    private volatile TContext _context;
+    private readonly TContext _context;
 
     internal List<InternalStep<TContext>> Steps { get; } = new();
     private InternalStep<TContext> LastStep => Steps[^1];
@@ -29,12 +28,12 @@ public sealed class PipelineBuilder<TContext, TResult>
     /// <param name="context">The pipeline context.</param>
     public PipelineBuilder(IPipelineStepFactory pipelineStepFactory, TContext context)
     {
-        ArgumentNullException.ThrowIfNull(pipelineStepFactory, nameof(pipelineStepFactory));
-        ArgumentNullException.ThrowIfNull(context, nameof(context));
+        ArgumentNullException.ThrowIfNull(pipelineStepFactory);
+        ArgumentNullException.ThrowIfNull(context);
 
         _pipelineStepFactory = pipelineStepFactory;
         _context = context;
-        _loggerFactory = pipelineStepFactory.ServiceProvider.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
+        _loggerFactory = pipelineStepFactory.GetLoggerFactory();
     }
 
     /// <summary>
@@ -105,6 +104,11 @@ public sealed class PipelineBuilder<TContext, TResult>
 
     /// <summary>
     /// Adds a parallel execution branch to the pipeline.
+    /// <para>
+    /// All steps within the parallel branch share the same <typeparamref name="TContext"/> instance.
+    /// Step implementations must not mutate shared context state without proper synchronization
+    /// (e.g., <c>Interlocked</c>, <c>lock</c>, or concurrent collections).
+    /// </para>
     /// </summary>
     /// <param name="action">An action to configure the parallel execution branch.</param>
     /// <param name="maxDegreeOfParallelism">The maximum degree of parallelism for the branch.</param>
@@ -156,6 +160,9 @@ public sealed class PipelineBuilder<TContext, TResult>
     /// <returns>The constructed pipeline.</returns>
     public IPipeline<TResult> Build()
     {
+        if (Steps.Count > 0 && Steps[^1] is FinishStep<TContext>)
+            return new Pipeline<TContext, TResult>(_context, Steps);
+
         Steps.Add(new FinishStep<TContext>());
 
         return new Pipeline<TContext, TResult>(_context, Steps);

--- a/src/PowerPipe/Builder/Steps/IfPipelineStep.cs
+++ b/src/PowerPipe/Builder/Steps/IfPipelineStep.cs
@@ -12,7 +12,6 @@ namespace PowerPipe.Builder.Steps;
 /// <typeparam name="TResult">The type of result returned by the sub-pipeline.</typeparam>
 internal class IfPipelineStep<TContext, TResult> : InternalStep<TContext>
     where TContext : PipelineContext<TResult>
-    where TResult : class
 {
     private readonly Predicate<TContext> _predicate;
     private readonly PipelineBuilder<TContext, TResult> _pipelineBuilder;

--- a/src/PowerPipe/Builder/Steps/ParallelStep.cs
+++ b/src/PowerPipe/Builder/Steps/ParallelStep.cs
@@ -6,12 +6,18 @@ namespace PowerPipe.Builder.Steps;
 
 /// <summary>
 /// Represents a parallel execution pipeline step.
+/// <para>
+/// Thread safety: all steps within a parallel branch share the same <typeparamref name="TContext"/> instance.
+/// Step implementations added via <c>Parallel()</c> must not mutate shared context state without
+/// proper synchronization (e.g., <c>Interlocked</c>, <c>lock</c>, or concurrent collections).
+/// Read-only access to context is safe. If steps need to write results, use thread-safe data structures
+/// or collect results independently and merge after parallel execution completes.
+/// </para>
 /// </summary>
 /// <typeparam name="TContext">The type of context used in the pipeline.</typeparam>
 /// <typeparam name="TResult">The type of result returned by the pipeline.</typeparam>
 internal class ParallelStep<TContext, TResult> : InternalStep<TContext>
     where TContext : PipelineContext<TResult>
-    where TResult : class
 {
     private readonly int _maxDegreeOfParallelism;
     private readonly PipelineBuilder<TContext, TResult> _pipelineBuilder;

--- a/src/PowerPipe/Exceptions/NestedPipelineExecutionException.cs
+++ b/src/PowerPipe/Exceptions/NestedPipelineExecutionException.cs
@@ -8,6 +8,34 @@ namespace PowerPipe.Exceptions;
 public class NestedPipelineExecutionException : Exception
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="NestedPipelineExecutionException"/> class.
+    /// </summary>
+    public NestedPipelineExecutionException()
+        : base("Nested pipeline execution failed")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NestedPipelineExecutionException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public NestedPipelineExecutionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NestedPipelineExecutionException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public NestedPipelineExecutionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="NestedPipelineExecutionException"/> class with a specified exception.
     /// </summary>
     /// <param name="exception">The inner exception that caused the nested pipeline execution to fail.</param>

--- a/src/PowerPipe/Exceptions/PipelineExecutionException.cs
+++ b/src/PowerPipe/Exceptions/PipelineExecutionException.cs
@@ -8,6 +8,34 @@ namespace PowerPipe.Exceptions;
 public class PipelineExecutionException : Exception
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="PipelineExecutionException"/> class.
+    /// </summary>
+    public PipelineExecutionException()
+        : base("Pipeline execution failed")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PipelineExecutionException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public PipelineExecutionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PipelineExecutionException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public PipelineExecutionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="PipelineExecutionException"/> class with a specified exception.
     /// </summary>
     /// <param name="exception">The inner exception that caused the pipeline execution to fail.</param>

--- a/src/PowerPipe/Factories/PipelineStepFactory.cs
+++ b/src/PowerPipe/Factories/PipelineStepFactory.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using PowerPipe.Interfaces;
 
 namespace PowerPipe.Factories;
@@ -6,8 +8,7 @@ namespace PowerPipe.Factories;
 /// <inheritdoc/>
 public class PipelineStepFactory : IPipelineStepFactory
 {
-    /// <inheritdoc/>
-    public IServiceProvider ServiceProvider { get; }
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PipelineStepFactory"/> class.
@@ -15,20 +16,28 @@ public class PipelineStepFactory : IPipelineStepFactory
     /// <param name="serviceProvider">The service provider to resolve step instances.</param>
     public PipelineStepFactory(IServiceProvider serviceProvider)
     {
-        ServiceProvider = serviceProvider;
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _serviceProvider = serviceProvider;
     }
 
     /// <inheritdoc/>
     public IStepBase<TContext> Create<TStep, TContext>()
         where TStep : IStepBase<TContext>
     {
-        return ServiceProvider.GetService(typeof(TStep)) as IStepBase<TContext>;
+        return _serviceProvider.GetRequiredService(typeof(TStep)) as IStepBase<TContext>;
     }
 
     /// <inheritdoc/>
     public IPipelineCompensationStep<TContext> CreateCompensation<TStep, TContext>()
         where TStep : IPipelineCompensationStep<TContext>
     {
-        return ServiceProvider.GetService(typeof(TStep)) as IPipelineCompensationStep<TContext>;
+        return _serviceProvider.GetRequiredService(typeof(TStep)) as IPipelineCompensationStep<TContext>;
+    }
+
+    /// <inheritdoc/>
+    public ILoggerFactory GetLoggerFactory()
+    {
+        return _serviceProvider.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
     }
 }

--- a/src/PowerPipe/Interfaces/IPipelineStep.cs
+++ b/src/PowerPipe/Interfaces/IPipelineStep.cs
@@ -8,6 +8,7 @@ public interface IPipelineStep<TContext> : IStepBase<TContext>
 {
     /// <summary>
     /// Gets or sets the next step in the pipeline.
+    /// This property is managed by the pipeline infrastructure and should not be set by consumer code.
     /// </summary>
     public IPipelineStep<TContext> NextStep { get; set; }
 }

--- a/src/PowerPipe/Interfaces/IPipelineStepFactory.cs
+++ b/src/PowerPipe/Interfaces/IPipelineStepFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
 
 namespace PowerPipe.Interfaces;
 
@@ -7,11 +7,6 @@ namespace PowerPipe.Interfaces;
 /// </summary>
 public interface IPipelineStepFactory
 {
-    /// <summary>
-    /// Instance of the service provider
-    /// </summary>
-    IServiceProvider ServiceProvider { get; }
-
     /// <summary>
     /// Creates an instance of a pipeline step.
     /// </summary>
@@ -29,4 +24,10 @@ public interface IPipelineStepFactory
     /// <returns>An instance of the specified pipeline compensation step.</returns>
     IPipelineCompensationStep<TContext> CreateCompensation<TStep, TContext>()
         where TStep : IPipelineCompensationStep<TContext>;
+
+    /// <summary>
+    /// Gets the logger factory for creating loggers within the pipeline.
+    /// </summary>
+    /// <returns>The logger factory, or null if logging is not configured.</returns>
+    ILoggerFactory GetLoggerFactory();
 }

--- a/src/PowerPipe/Pipeline.cs
+++ b/src/PowerPipe/Pipeline.cs
@@ -8,7 +8,6 @@ namespace PowerPipe;
 /// <inheritdoc/>
 public class Pipeline<TContext, TResult> : IPipeline<TResult>
     where TContext : PipelineContext<TResult>
-    where TResult : class
 {
     private readonly TContext _context;
     private readonly IPipelineStep<TContext> _initStep;
@@ -33,7 +32,7 @@ public class Pipeline<TContext, TResult> : IPipeline<TResult>
         await _initStep.ExecuteAsync(_context, cancellationToken);
 
         // to avoid multiple result calls in nested pipelines
-        return returnResult ? _context.GetPipelineResult() : null;
+        return returnResult ? _context.GetPipelineResult() : default;
     }
 
     private static void SetupSteps(IReadOnlyList<IPipelineStep<TContext>> steps)

--- a/src/PowerPipe/PipelineContext.cs
+++ b/src/PowerPipe/PipelineContext.cs
@@ -5,7 +5,6 @@
 /// </summary>
 /// <typeparam name="TResult">The type of result returned by the pipeline.</typeparam>
 public abstract class PipelineContext<TResult>
-    where TResult : class
 {
     /// <summary>
     /// Gets the result of the pipeline execution.

--- a/tests/PowerPipe.UnitTests/Steps/TestParallelStep.cs
+++ b/tests/PowerPipe.UnitTests/Steps/TestParallelStep.cs
@@ -12,6 +12,4 @@ public class TestParallelStep : IPipelineParallelStep<TestPipelineContext>
 
         return ValueTask.CompletedTask;
     }
-
-    public IPipelineStep<TestPipelineContext> NextStep { get; set; }
 }


### PR DESCRIPTION
## Changes

### Bug fixes
- **PipelineStepFactory**: `Create` and `CreateCompensation` now throw `InvalidOperationException` with the unregistered type name instead of silently returning `null` (which caused a `NullReferenceException` downstream)
- **PipelineBuilder.Build()**: Guard against duplicate `FinishStep` — calling `Build()` multiple times no longer corrupts the pipeline
- **PipelineBuilder**: Removed incorrect `volatile` modifier from `_context` (field is only assigned in the constructor)

### API improvements
- **IPipelineStepFactory**: Removed `IServiceProvider ServiceProvider` property (Service Locator anti-pattern). Added `ILoggerFactory GetLoggerFactory()` instead. `PipelineBuilder` now uses this method to obtain the logger factory
- **PipelineContext / PipelineBuilder / Pipeline**: Dropped `where TResult : class` constraint, allowing value types and record structs as pipeline results. `RunAsync` returns `default(TResult)` instead of `null` for nested pipelines
- **PipelineExecutionException / NestedPipelineExecutionException**: Added standard .NET exception constructors (parameterless, `(string)`, `(string, Exception)`)

### Documentation
- **PipelineBuilder.Parallel()** and **ParallelStep**: Added XML doc warning that parallel steps share the same context instance and must synchronize writes (e.g. `Interlocked`, `lock`, concurrent collections)
- **IPipelineStep.NextStep**: Documented that the setter is managed by pipeline infrastructure and should not be set by consumer code
- **PipelineDiagramsService.GetDiagrams()**: Documented that diagrams are cached after the first call with no invalidation

### Logging
- **PipelineDiagramsService.GetDiagrams()**: Changed exception logging from `LogDebug` to `LogError`

### Test cleanup
- **TestParallelStep**: Removed unused `NextStep` property